### PR TITLE
Section Tabs > getTabSelector() expecting a view, but was passing a hash

### DIFF
--- a/source/providers/inputs/Pict-Provider-Input-TabSectionSelector.js
+++ b/source/providers/inputs/Pict-Provider-Input-TabSectionSelector.js
@@ -40,9 +40,9 @@ class CustomInputHandler extends libPictSectionInputExtension
 		return `PictSectionForm-${pManifestSectionHash}`;
 	}
 
-	getTabSelector(pTabView, pInput)
+	getTabSelector(pTabSectionHash, pInput)
 	{
-		return `#TAB-${pTabView.formID}-${pInput.Macro.RawHTMLID}`;
+		return `#TAB-${pTabSectionHash}-${pInput.Macro.RawHTMLID}`;
 	}
 
 	getSectionSelector(pTabViewSectionHash)


### PR DESCRIPTION
This corrects the "active" styling on the Section Tabs UI.