### PR TITLE
Section/Group Tabs > Display Names - add missing display labels to UI

### DIFF
--- a/source/providers/dynamictemplates/Pict-DynamicTemplates-DefaultFormTemplates.js
+++ b/source/providers/dynamictemplates/Pict-DynamicTemplates-DefaultFormTemplates.js
@@ -418,7 +418,7 @@ Glug glug glug Oo... -->
 			"HashPostfix": "-Template-Input-InputType-TabGroupSelector-TabElement",
 			"Template": /*HTML*/`
 			<!-- Sections have "tab groups" which are defined by the hash of the Descriptor that hosts the current TabGroup value. -->
-			<a href="#/" id="TAB-{~D:Context[1].TabGroupHash~}-{~D:Record.Macro.RawHTMLID~}" onclick="{~P~}.providers['Pict-Input-TabGroupSelector'].selectTabByViewHash('{~D:Context[0].Hash~}','{~D:Record.Hash~}', '{~D:Context[1].TabGroupHash~}')">{~D:Context[1].TabGroupHash~}</a>
+			<a href="#/" id="TAB-{~D:Context[1].TabGroupHash~}-{~D:Record.Macro.RawHTMLID~}" onclick="{~P~}.providers['Pict-Input-TabGroupSelector'].selectTabByViewHash('{~D:Context[0].Hash~}','{~D:Record.Hash~}', '{~D:Context[1].TabGroupHash~}')">{~D:Context[1].TabGroupName~}</a>
 `
 		},
 		{
@@ -453,7 +453,7 @@ Glug glug glug Oo... -->
 			"HashPostfix": "-Template-Input-InputType-TabSectionSelector-TabElement",
 			"Template": /*HTML*/`
 			<!-- Sections have "tab groups" which are defined by the hash of the Descriptor that hosts the current TabSection value. -->
-			<a href="#/" id="TAB-{~D:Context[1].TabSectionHash~}-{~D:Record.Macro.RawHTMLID~}" onclick="{~P~}.providers['Pict-Input-TabSectionSelector'].selectTabByViewHash('{~D:Context[0].Hash~}','{~D:Record.Hash~}', '{~D:Context[1].TabSectionHash~}')">{~D:Context[1].TabSectionHash~}</a>
+			<a href="#/" id="TAB-{~D:Context[1].TabSectionHash~}-{~D:Record.Macro.RawHTMLID~}" onclick="{~P~}.providers['Pict-Input-TabSectionSelector'].selectTabByViewHash('{~D:Context[0].Hash~}','{~D:Record.Hash~}', '{~D:Context[1].TabSectionHash~}')">{~D:Context[1].TabSectionName~}</a>
 `
 		},
 		{

--- a/source/providers/inputs/Pict-Provider-Input-TabGroupSelector.js
+++ b/source/providers/inputs/Pict-Provider-Input-TabGroupSelector.js
@@ -121,10 +121,12 @@ class CustomInputHandler extends libPictSectionInputExtension
 		let tmpEntryMetatemplateHash = this.pict.providers.DynamicInput.getInputTemplateHash(pView, { PictForm: { InputType: 'TabGroupSelector-TabElement', DataType: 'String' } });
 
 		let tmpTabGroupSetEntries = '';
+		// If there are tab group names, use them, otherwise use the hash
+		let tempTabSetNames = pInput.PictForm?.TabGroupNames || [];
 
 		for (let i = 0; i < tmpTabSet.length; i++)
 		{
-			tmpTabGroupSetEntries += this.pict.parseTemplateByHash(tmpEntryMetatemplateHash, pInput, null, [pView, {TabGroupHash: tmpTabSet[i]}]);
+			tmpTabGroupSetEntries += this.pict.parseTemplateByHash(tmpEntryMetatemplateHash, pInput, null, [pView, {TabGroupHash: tmpTabSet[i], TabGroupName: (tempTabSetNames[i] || tmpTabSet[i])}]);
 		}
 
 		// TODO: Fix typescript types so this function has an optional rather than required fourth parameter.

--- a/source/providers/inputs/Pict-Provider-Input-TabSectionSelector.js
+++ b/source/providers/inputs/Pict-Provider-Input-TabSectionSelector.js
@@ -132,10 +132,12 @@ class CustomInputHandler extends libPictSectionInputExtension
 		let tmpEntryMetatemplateHash = this.pict.providers.DynamicInput.getInputTemplateHash(pView, { PictForm: { InputType: 'TabSectionSelector-TabElement', DataType: 'String' } });
 
 		let tmpTabSectionSetEntries = '';
+		// If there are tab group names, use them, otherwise use the hash
+		let tempTabSetNames = pInput.PictForm?.TabSectionNames || [];
 
 		for (let i = 0; i < tmpTabSet.length; i++)
 		{
-			tmpTabSectionSetEntries += this.pict.parseTemplateByHash(tmpEntryMetatemplateHash, pInput, null, [pView, {TabSectionHash: tmpTabSet[i]}]);
+			tmpTabSectionSetEntries += this.pict.parseTemplateByHash(tmpEntryMetatemplateHash, pInput, null, [pView, {TabSectionHash: tmpTabSet[i], TabSectionName: (tempTabSetNames[i] || tmpTabSet[i])}]);
 		}
 
 		// TODO: Fix typescript types so this function has an optional rather than required fourth parameter.


### PR DESCRIPTION
The "Tab Section Names" and "Tab Group Names" arrays were not being included/applied to the UI tabs. Added these in the respective providers.