### PR TITLE
Add "Section CSS" support for section-wrapper classes

### DIFF
--- a/example_applications/complex_table/Complex-Tabular-Application.js
+++ b/example_applications/complex_table/Complex-Tabular-Application.js
@@ -116,10 +116,12 @@ module.exports.default_configuration.pict_configuration = {
 			{
 				Hash: "Book",
 				Name: "Books about Tables",
+				CSSClass: "HasFancyHeaders",
 				Groups: [
 					{
 						Hash: "Author",
-						Name: "Author"
+						Name: "Author",
+						CSSClass: "FancyCustomGroupTitleOverride",
 					},
 					{
 						Hash: "Book",

--- a/example_applications/complex_table/html/index.html
+++ b/example_applications/complex_table/html/index.html
@@ -5,6 +5,33 @@
 		<style id="PICT-CSS"></style>
 		<script src="./pict.min.js" type="text/javascript"></script>
 		<script type="text/javascript">Pict.safeOnDocumentReady(() => { Pict.safeLoadPictApplication(ComplexTabularApplication, 0)});</script>
+		<!-- CSS placed here to simulate an external collection where we can leverage existing class names/patterns -->
+		<style type="text/css">
+			.HasFancyHeaders h2
+			{
+				font-weight: bold;
+				text-transform: uppercase;
+				font-style: italic;
+				color: maroon;
+				text-decoration: underline;
+				margin: 0.5em 0;
+			}
+			.HasFancyHeaders h3
+			{
+				font-weight: bold;
+				font-style: italic;
+				color: brown;
+				text-decoration: underline;
+				margin: 0.5em 0;
+			}
+			.FancyCustomGroupTitleOverride > h3 {
+				font-weight: bold;
+				font-style: italic;
+				color: darkblue;
+				text-decoration: underline;
+				margin: 0.5em 0;
+			}
+		</style>
 	</head>
 	<body>
 		<div id="Pict-Form-Container"></div>

--- a/source/providers/dynamictemplates/Pict-DynamicTemplates-DefaultFormTemplates.js
+++ b/source/providers/dynamictemplates/Pict-DynamicTemplates-DefaultFormTemplates.js
@@ -79,7 +79,7 @@ Glug glug glug Oo... -->
 			"HashPostfix": "-Template-Section-Prefix",
 			"Template": /*HTML*/`
 		<!-- Form Section Prefix [{~D:Context[0].UUID~}]::[{~D:Context[0].Hash~}] {~D:Record.Hash~}::{~D:Record.Name~} -->
-		<div id="SECTION-{~D:Context[0].formID~}" class="pict-form-section">
+		<div id="SECTION-{~D:Context[0].formID~}" class="pict-form-section {~D:Record.CSSClass~}">
 		<h2>{~D:Record.Name~}</h2>
 `
 		},
@@ -100,8 +100,8 @@ Glug glug glug Oo... -->
 			"HashPostfix": "-Template-Group-Prefix",
 			"Template": /*HTML*/`
 			<!-- Form Template Group Prefix [{~D:Context[0].UUID~}]::[{~D:Context[0].Hash~}] {~D:Record.Hash~}::{~D:Record.Name~} -->
-			<div id="GROUP-{~D:Context[0].formID~}-{~D:Record.Hash~}" {~D:Record.Macro.PictFormLayout~}>
-			<h3 class="{~D:Record.CSSClass~}">Group: {~D:Record.Name~}</h3>
+			<div id="GROUP-{~D:Context[0].formID~}-{~D:Record.Hash~}" class="{~D:Record.CSSClass~}" {~D:Record.Macro.PictFormLayout~}>
+			<h3>Group: {~D:Record.Name~}</h3>
 `
 		},
 		// row(s) are useful when our form has multiple inputs on some lines and a single on another...

--- a/source/services/ManifestFactory.js
+++ b/source/services/ManifestFactory.js
@@ -535,6 +535,11 @@ class ManifestFactory extends libFableServiceProviderBase
 			tmpSection.Name = tmpSectionName;
 		}
 
+		if (tmpSection['Section CSS'])
+		{
+			tmpSection.CSSClass = tmpSection['Section CSS'];
+		}
+
 		const tmpGroupName = tmpRecord['Group Name']?.trim?.();
 		let tmpGroupHash = this.sanitizeObjectKey(tmpGroupName || 'Default_Group');
 		// Note: The group name part is laissez-faire about whether it needs to be there or not.  The Hash is required on each column if we want to customize.


### PR DESCRIPTION
- Add support for the section-wide classes that can be applied to the section element wrapper
- Found and fixed a bug in "Group CSS" where the class was applied to the `h3` instead of the group-wide `div`
- Added an use cases for both Section CSS and Group CSS in the "Complex Table" example
![screenshot 37](https://github.com/user-attachments/assets/37efc5cf-2d0f-4eb8-9b72-5192cddb1212)
