### PR TITLE
Bug fix for 'colorInputBackground()' view hash

### DIFF
--- a/source/providers/Pict-Provider-DynamicFormSolverBehaviors.js
+++ b/source/providers/Pict-Provider-DynamicFormSolverBehaviors.js
@@ -299,7 +299,7 @@ class PictDynamicFormsSolverBehaviors extends libPictProvider
 			this.log.warn(`PictDynamicFormsInformary: colorInput could not find input with section hash [${pSectionHash}] input [${pInputHash}].`);
 			return false;
 		}
-		// check for both input and select
+
 		let tmpElementSet = this.pict.ContentAssignment.getElement(`#${tmpInput.Macro.RawHTMLID}`);
 
 		if (tmpElementSet.length < 1)
@@ -308,7 +308,7 @@ class PictDynamicFormsSolverBehaviors extends libPictProvider
 			return false;
 		}
 
-		// if there's a parent element, use that instead and we can color the whole input container and cascade the color down as needed in templates
+		// if there's a parent element, use that instead and we can color the whole input container area
 		if (tmpElementSet[0].parentElement)
 		{
 			tmpElementSet = [ tmpElementSet[0].parentElement ];


### PR DESCRIPTION
Discovered that "getInputViewFromHash()" is not a valid method on PictFormMetacontroller, looks like might have been a co-pilot auto complete mix up and should be using the Section view hash like all the sibling methods. Also, `formID` is a view section view property, not an HTML Input property, so had to swap the ID to the Macro pattern.